### PR TITLE
Stop synthetic humans vomiting from flipping too much

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -84,10 +84,10 @@
 // BUBBER EDIT CHANGE BEGIN - Flip Cooldown
 /datum/emote/flip/run_emote(mob/user, params , type_override, intentional)
 	. = ..()
-	var/mob/living/carbon/flippy_mcgee = user
-	if(flippy_mcgee)
+	if(iscarbon(user))
+		var/mob/living/carbon/flippy_mcgee = user
 		flippy_mcgee.set_confusion_if_lower(FLIP_EMOTE_DURATION)
-		if(flippy_mcgee.get_timed_status_effect_duration(/datum/status_effect/confusion) > BEYBLADE_PUKE_THRESHOLD)
+		if(!issynthetic(flippy_mcgee) && flippy_mcgee.get_timed_status_effect_duration(/datum/status_effect/confusion) > BEYBLADE_PUKE_THRESHOLD)
 			flippy_mcgee.vomit(VOMIT_CATEGORY_KNOCKDOWN, lost_nutrition = BEYBLADE_PUKE_NUTRIENT_LOSS, distance = 0)
 			return
 


### PR DESCRIPTION

## About The Pull Request
Dunno if this is the ideal fix or if the vomit proc needs an override for checking issynthetic.
## Why It's Good For The Game
Synths are more agile and don't spew chunks
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Synths don't vomit when flipping too much
/:cl:
